### PR TITLE
fix: Make this package work with pymarkdown 3.4.

### DIFF
--- a/mdx_include/mdx_include.py
+++ b/mdx_include/mdx_include.py
@@ -39,7 +39,7 @@ from . import version
 
 __version__ = version.__version__
 
-MARKDOWN_MAJOR = markdown.version_info[0]
+MARKDOWN_MAJOR = markdown.__version_info__[0]
 
 logging.basicConfig()
 LOGGER_NAME = 'mdx_include-' + __version__

--- a/mdx_include/mdx_include.py
+++ b/mdx_include/mdx_include.py
@@ -39,7 +39,7 @@ from . import version
 
 __version__ = version.__version__
 
-MARKDOWN_MAJOR = markdown.__version_info__[0]
+MARKDOWN_MAJOR = (markdown.__version_info__ if hasattr(markdown, "__version_info__") else markdown.version_info)[0]
 
 logging.basicConfig()
 LOGGER_NAME = 'mdx_include-' + __version__

--- a/mdx_include/test/test.py
+++ b/mdx_include/test/test.py
@@ -22,7 +22,7 @@ def get_file_content(path):
     return cont
 
 def assertEqual(self, html, output):
-    if tuple(markdown.__version_info__) >= (3, 3):
+    if tuple(markdown.__version_info__ if hasattr(markdown, "__version_info__") else markdown.version_info) >= (3, 3):
         html = html.replace('ass="language-', 'ass="')
         html = html.replace('\n\n<p>', '<p>')
         html = html.replace('\n<p>', '<p>')

--- a/mdx_include/test/test.py
+++ b/mdx_include/test/test.py
@@ -22,7 +22,7 @@ def get_file_content(path):
     return cont
 
 def assertEqual(self, html, output):
-    if tuple(markdown.version_info) >= (3, 3):
+    if tuple(markdown.__version_info__) >= (3, 3):
         html = html.replace('ass="language-', 'ass="')
         html = html.replace('\n\n<p>', '<p>')
         html = html.replace('\n<p>', '<p>')


### PR DESCRIPTION
closes #7

remove lines that access deprecated attribute `version_info` of python-markdown.
